### PR TITLE
fix: input not being aligned with frame

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,7 @@
       let food = {x: 15, y: 10};
       let score = 0;
       let gameInterval;
+      let pressed = false;
       const segmentDivs = [];
 
       // Initialize the game
@@ -138,6 +139,7 @@
 
       // Handle direction changes via arrow keys
       function handleKeyPress(event) {
+          if (pressed) return;
           let newDirection;
           if (event.key === 'ArrowRight' && direction !== 'left') newDirection = 'right';
           else if (event.key === 'ArrowLeft' && direction !== 'right') newDirection = 'left';
@@ -145,6 +147,7 @@
           else if (event.key === 'ArrowDown' && direction !== 'up') newDirection = 'down';
           if (newDirection) {
               direction = newDirection;
+              pressed = true;
           }
       }
 
@@ -210,6 +213,8 @@
                   return;
               }
           }
+
+          pressed = false;
       }
 
       // Place new food at a random empty position


### PR DESCRIPTION
The key press event listener, when bound, will not automatically align with the frame rate; This leads to inputs overlapping in a single frame if keys are quickly pressed in sequence.
The proposed change adds a flag to keep track of when a key is pressed in the current frame and resets it when the frame is over.
This limits the amount of times you can effectively change directions in the set amount of time for the game loop interval.

The obvious pro of this change is the more intuitive movement, but a noticeable con is the inputs feeling delayed, which could instead be solved using a FIFO queue where each input is saved and then popped on each frame.